### PR TITLE
Fix issues (mainly with git integration)

### DIFF
--- a/src/components/artifact/Launch.vue
+++ b/src/components/artifact/Launch.vue
@@ -29,6 +29,17 @@ const sharingKey = computed(() => {
         color="primary"
         label="Download Archive"
         :href="artifact.computed.get_chameleon_download_url(version_slug, sharingKey)"
+        v-if="artifact.computed.github_url"
+        target="_blank"
+        class="full-width"
+      />
+    </div>
+
+    <div v-if="artifact.reproducibility.enable_requests" class="q-mb-sm">
+      <q-btn
+        color="primary"
+        label="Request daypass"
+        :href="artifact.computed.get_chameleon_request_daypass_url()"
         target="_blank"
         class="full-width"
       />
@@ -40,8 +51,21 @@ const sharingKey = computed(() => {
         label="View on GitHub"
         :href="artifact.computed.github_url"
         target="_blank"
-        class="full-width"
+        class="full-width q-mb-sm"
       />
+
+      <div
+        class="bg-grey-2 rounded-borders q-pa-sm"
+        style="max-width: 100%; overflow-x: auto; white-space: pre; font-family: monospace"
+      >
+        <code>
+          <pre>
+git clone {{ artifact.computed.github_url }}
+# cd into the created directory git checkout
+{{ artifact.computed.git_ref }}</pre
+          >
+        </code>
+      </div>
     </div>
   </div>
 </template>

--- a/src/views/EditArtifactView.vue
+++ b/src/views/EditArtifactView.vue
@@ -407,7 +407,7 @@ const reimportArtifact = async () => {
               <div>{{ version.created_at }}</div>
               <div class="row q-gutter-sm">
                 <q-btn
-                  v-if="!version.computed?.doi && !version.doi_request"
+                  v-if="!version.computed?.doi && !version.doi_request && !version.computed?.is_git"
                   color="secondary"
                   label="Request DOI"
                   @click="version.doi_request = true"


### PR DESCRIPTION
- fix parsing of git versions - before it only worked if `.git` was included in the url
- hide "request DOI" for git versions - trovi only supports `swift -> zenodo` 
- add `git clone` code - requested in user ticket
- fix missing "request daypass" button" - I missed this as it only pops up on a few artifacts