### PR TITLE
Add "Artifact Links" to support collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "primevue": "^4.0.5",
         "quasar": "^2.18.5",
         "vue": "^3.4.29",
-        "vue-router": "^4.4.0"
+        "vue-router": "^4.4.0",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
@@ -4881,6 +4882,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5510,6 +5517,18 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/webpack-virtual-modules": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "primevue": "^4.0.5",
     "quasar": "^2.18.5",
     "vue": "^3.4.29",
-    "vue-router": "^4.4.0"
+    "vue-router": "^4.4.0",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -11,7 +11,7 @@ const props = defineProps({
   <div class="relative-position full-size">
     <!-- Wrapped content -->
     <div :class="{ 'q-opacity-50 q-pointer-events-none': props.loading }">
-      <slot />
+      <slot></slot>
     </div>
 
     <!-- Loading overlay -->

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { useRoute } from 'vue-router'
-import logo from '@/assets/img/logo.png'
 import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()

--- a/src/components/TagFilter.vue
+++ b/src/components/TagFilter.vue
@@ -1,17 +1,26 @@
 <script setup>
-import { reactive, watch } from 'vue'
+import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ArtifactBadge from '@/components/artifact/ArtifactBadge.vue'
 
 const props = defineProps({
   tags: { type: Array, default: () => [] },
-  badges: { type: Object, default: () => {} },
+  badges: { type: [Array, Object], default: () => [] },
+  // optional v-model bindings so TagFilter can be controlled by parent
+  selectedTags: { type: Array, default: null },
+  selectedBadges: { type: Array, default: null },
+  filterOwned: { type: Boolean, default: null },
+  filterPublic: { type: Boolean, default: null },
+  filterDoi: { type: Boolean, default: null },
+  filterCollection: { type: Boolean, default: null },
+  searchText: { type: String, default: null },
 })
 const emit = defineEmits([
   'update:selectedTags',
   'update:selectedBadges',
   'update:filterOwned',
   'update:filterPublic',
+  'update:filterCollection',
   'update:filterDoi',
   'update:searchText',
 ])
@@ -19,63 +28,101 @@ const emit = defineEmits([
 const route = useRoute()
 const router = useRouter()
 
-// Local reactive state synced with query params
-const state = reactive({
-  selectedTags: route.query.tags ? route.query.tags.split(',') : [],
-  selectedBadges: route.query.badges ? route.query.badges.split(',') : [],
-  filterOwned: route.query.owned === '1',
-  filterPublic: route.query.public === '1',
-  filterDoi: route.query.doi === '1',
-  searchText: route.query.q || '',
+// Component is largely stateless: expose computed getters/setters that
+// read from provided props when present, otherwise fall back to route query.
+// Setters emit update events and update the URL query parameters.
+
+const selectedTags = computed({
+  get() {
+    if (Array.isArray(props.selectedTags)) return props.selectedTags
+    if (route.query.tags) return String(route.query.tags).split(',')
+    return []
+  },
+  set(val) {
+    const next = Array.isArray(val) ? val : []
+    emit('update:selectedTags', next)
+    updateQuery({ tags: next.length ? next.join(',') : undefined })
+  },
 })
 
-// Watchers to emit events and update query params
-watch(
-  () => state.selectedTags,
-  (val) => {
-    emit('update:selectedTags', val)
-    updateQuery({ tags: val.join(',') })
+const selectedBadges = computed({
+  get() {
+    if (Array.isArray(props.selectedBadges)) return props.selectedBadges
+    if (route.query.badges) return String(route.query.badges).split(',')
+    return []
   },
-  { deep: true },
-)
+  set(val) {
+    const next = Array.isArray(val) ? val : []
+    emit('update:selectedBadges', next)
+    updateQuery({ badges: next.length ? next.join(',') : undefined })
+  },
+})
 
-watch(
-  () => state.selectedBadges,
-  (val) => {
-    emit('update:selectedBadges', val)
-    updateQuery({ badges: val.join(',') })
+const filterOwned = computed({
+  get() {
+    if (typeof props.filterOwned === 'boolean') return props.filterOwned
+    return route.query.owned === '1'
   },
-  { deep: true },
-)
+  set(val) {
+    const b = !!val
+    emit('update:filterOwned', b)
+    updateQuery({ owned: b ? '1' : undefined })
+  },
+})
 
-watch(
-  () => state.filterOwned,
-  (val) => {
-    emit('update:filterOwned', val)
-    updateQuery({ owned: val ? '1' : undefined })
+const filterPublic = computed({
+  get() {
+    if (typeof props.filterPublic === 'boolean') return props.filterPublic
+    return route.query.public === '1'
   },
-)
-watch(
-  () => state.filterPublic,
-  (val) => {
-    emit('update:filterPublic', val)
-    updateQuery({ public: val ? '1' : undefined })
+  set(val) {
+    const b = !!val
+    emit('update:filterPublic', b)
+    updateQuery({ public: b ? '1' : undefined })
   },
-)
-watch(
-  () => state.filterDoi,
-  (val) => {
-    emit('update:filterDoi', val)
-    updateQuery({ doi: val ? '1' : undefined })
+})
+
+const filterDoi = computed({
+  get() {
+    if (typeof props.filterDoi === 'boolean') return props.filterDoi
+    return route.query.doi === '1'
   },
-)
-watch(
-  () => state.searchText,
-  (val) => {
-    emit('update:searchText', val)
-    updateQuery({ q: val || undefined })
+  set(val) {
+    const b = !!val
+    emit('update:filterDoi', b)
+    updateQuery({ doi: b ? '1' : undefined })
   },
-)
+})
+
+const filterCollection = computed({
+  get() {
+    if (typeof props.filterCollection === 'boolean') return props.filterCollection
+    return route.query.collection === '1'
+  },
+  set(val) {
+    const b = !!val
+    emit('update:filterCollection', b)
+    updateQuery({ collection: b ? '1' : undefined })
+  },
+})
+
+const searchText = computed({
+  get() {
+    if (typeof props.searchText === 'string') return props.searchText
+    return route.query.q || ''
+  },
+  set(val) {
+    const s = val || ''
+    emit('update:searchText', s)
+    updateQuery({ q: s || undefined })
+  },
+})
+
+const badgesList = computed(() => {
+  if (Array.isArray(props.badges)) return props.badges
+  if (props.badges && typeof props.badges === 'object') return Object.values(props.badges)
+  return []
+})
 
 function updateQuery(newParams) {
   router.replace({ query: { ...route.query, ...newParams } })
@@ -87,7 +134,7 @@ function updateQuery(newParams) {
     <div class="row items-center q-gutter-sm">
       <q-input
         filled
-        v-model="state.searchText"
+        v-model="searchText"
         placeholder="Search artifacts..."
         clearable
         class="full-width"
@@ -101,7 +148,7 @@ function updateQuery(newParams) {
           v-for="(tag, index) in tags"
           :key="index"
           :val="tag"
-          v-model="state.selectedTags"
+          v-model="selectedTags"
           label-class="text-subtitle2"
           :label="tag"
           dense
@@ -115,10 +162,10 @@ function updateQuery(newParams) {
       </div>
       <div class="col q-gutter-sm row wrap">
         <q-checkbox
-          v-for="(badge, index) in badges"
+          v-for="(badge, index) in badgesList"
           :key="index"
           :val="badge.name"
-          v-model="state.selectedBadges"
+          v-model="selectedBadges"
           dense
         >
           <ArtifactBadge :badge="badge" :link="false" />
@@ -133,13 +180,16 @@ function updateQuery(newParams) {
       </div>
 
       <div class="col-auto">
-        <q-checkbox v-model="state.filterOwned" label="My Artifacts" dense />
+        <q-checkbox v-model="filterOwned" label="My Artifacts" dense />
       </div>
       <div class="col-auto">
-        <q-checkbox v-model="state.filterPublic" label="Public" dense />
+        <q-checkbox v-model="filterPublic" label="Public" dense />
       </div>
       <div class="col-auto">
-        <q-checkbox v-model="state.filterDoi" label="Has DOI" dense />
+        <q-checkbox v-model="filterCollection" label="Is collection" dense />
+      </div>
+      <div class="col-auto">
+        <q-checkbox v-model="filterDoi" label="Has DOI" dense />
       </div>
     </div>
   </div>

--- a/src/components/TagFilter.vue
+++ b/src/components/TagFilter.vue
@@ -22,6 +22,7 @@ const emit = defineEmits([
   'update:filterPublic',
   'update:filterCollection',
   'update:filterDoi',
+  'update:filterCollection',
   'update:searchText',
 ])
 

--- a/src/components/artifact/ArtifactCitation.vue
+++ b/src/components/artifact/ArtifactCitation.vue
@@ -56,8 +56,6 @@ const latestVersion = computed(
 )
 
 const authorList = computed(() => props.artifact?.authors?.map((a) => a.full_name).join(', ') ?? '')
-const year = computed(() => latestVersion.value?.created_at?.split('-')[0] ?? '')
-const month = computed(() => latestVersion.value?.created_at?.split('-')[1] ?? '')
 const troviUrl = computed(() =>
   props.artifact?.uuid ? `https://trovi.chameleoncloud.org/artifacts/${props.artifact.uuid}` : '',
 )
@@ -73,11 +71,11 @@ const doi = computed(() => {
   return `${latestDoi}.` || ''
 })
 const citation = computed(() =>
-  `${authorList.value}. (${year.value}). ${props.artifact?.title ?? ''}. Trovi. ${troviUrl.value}. ${doi.value}`.trim(),
+  `${authorList.value}. (${props.artifact.computed.latestYear}). ${props.artifact?.title ?? ''}. Trovi. ${troviUrl.value}. ${doi.value}`.trim(),
 )
 const bibtexKey = computed(() => {
   const author = props.artifact?.authors?.[0]?.full_name?.split(' ')[0] ?? 'author'
-  const yr = year.value || 'year'
+  const yr = props.artifact.computed.latestYear || 'year'
   const titleWords = props.artifact?.title?.split(' ').slice(0, 2).join('_') ?? 'title'
   return `${author}_${yr}_${titleWords}`.toLowerCase()
 })
@@ -96,8 +94,8 @@ const bibtex = computed(() => {
     title={${props.artifact?.title ?? ''}},
     publisher={{Trovi}},
     url={${troviUrl.value}},${doi.value ? `\n    doi={${doi.value}},` : ''}
-    year={${year.value}},
-    month={${month.value}},${note.value ? `\n    note={${note.value}},` : ''}
+    year={${props.artifact.computed.latestYear}},
+    month={${props.artifact.computed.latestMonth}},${note.value ? `\n    note={${note.value}},` : ''}
   }
 }`
 })

--- a/src/components/artifact/ArtifactLinks.vue
+++ b/src/components/artifact/ArtifactLinks.vue
@@ -1,0 +1,23 @@
+<script setup>
+const props = defineProps({ artifact: Object })
+</script>
+
+<template>
+  <div v-if="artifact.linked_artifacts.length > 0" class="q-mb-lg">
+    <h2 class="text-h6 text-primary q-mb-md">Related Artifacts</h2>
+    <ol class="q-mb-sm">
+      <li v-for="a in artifact.linked_artifacts" :key="a.linked_artifact">
+        <a :href="'/artifacts/' + a.linked_artifact"> "{{ a.linked_title }}" </a>
+      </li>
+    </ol>
+  </div>
+
+  <div v-if="artifact.linked_from.length > 0" class="q-mb-lg">
+    <h2 class="text-h6 text-primary">Part of Collections</h2>
+    <ol class="q-mb-sm">
+      <li v-for="a in artifact.linked_from" :key="a.source_artifact">
+        <a :href="'/artifacts/' + a.source_artifact"> "{{ a.linked_from_title }}" </a>
+      </li>
+    </ol>
+  </div>
+</template>

--- a/src/components/artifact/ArtifactLinks.vue
+++ b/src/components/artifact/ArtifactLinks.vue
@@ -11,13 +11,4 @@ const props = defineProps({ artifact: Object })
       </li>
     </ol>
   </div>
-
-  <div v-if="artifact.linked_from.length > 0" class="q-mb-lg">
-    <h2 class="text-h6 text-primary">Part of Collections</h2>
-    <ol class="q-mb-sm">
-      <li v-for="a in artifact.linked_from" :key="a.source_artifact">
-        <a :href="'/artifacts/' + a.source_artifact"> "{{ a.linked_from_title }}" </a>
-      </li>
-    </ol>
-  </div>
 </template>

--- a/src/components/artifact/ArtifactLinksFrom.vue
+++ b/src/components/artifact/ArtifactLinksFrom.vue
@@ -1,0 +1,14 @@
+<script setup>
+const props = defineProps({ artifact: Object })
+</script>
+
+<template>
+  <div v-if="artifact.linked_from.length > 0" class="q-mb-lg">
+    <h2 class="text-h6 text-primary">Related to:</h2>
+    <ol class="q-mb-sm">
+      <li v-for="a in artifact.linked_from" :key="a.source_artifact">
+        <a :href="'/artifacts/' + a.source_artifact"> "{{ a.linked_from_title }}" </a>
+      </li>
+    </ol>
+  </div>
+</template>

--- a/src/components/artifact/ArtifactLinksFrom.vue
+++ b/src/components/artifact/ArtifactLinksFrom.vue
@@ -1,12 +1,25 @@
 <script setup>
+import { computed } from 'vue'
+
 const props = defineProps({ artifact: Object })
+
+// Compute a sorted list with owned items first
+const sortedLinkedFrom = computed(() => {
+  if (!props.artifact?.linked_from) return []
+  return [...props.artifact.linked_from].sort((a, b) => {
+    const owner = props.artifact.owner_urn
+    const aOwned = a.linked_from_owner === owner ? 0 : 1
+    const bOwned = b.linked_from_owner === owner ? 0 : 1
+    return aOwned - bOwned
+  })
+})
 </script>
 
 <template>
   <div v-if="artifact.linked_from.length > 0" class="q-mb-lg">
     <h2 class="text-h6 text-primary">Related to:</h2>
     <ol class="q-mb-sm">
-      <li v-for="a in artifact.linked_from" :key="a.source_artifact">
+      <li v-for="a in sortedLinkedFrom" :key="a.source_artifact">
         <a :href="'/artifacts/' + a.source_artifact"> "{{ a.linked_from_title }}" </a>
       </li>
     </ol>

--- a/src/components/artifact/ArtifactList.vue
+++ b/src/components/artifact/ArtifactList.vue
@@ -74,6 +74,7 @@ onMounted(async () => {
       v-model:selectedBadges="state.selectedBadges"
       v-model:filterDoi="state.filterDoi"
       v-model:searchText="state.searchText"
+      v-model:filterCollection="state.filterCollection"
     />
 
     <div class="row justify-end">

--- a/src/components/artifact/ArtifactMetrics.vue
+++ b/src/components/artifact/ArtifactMetrics.vue
@@ -19,10 +19,21 @@ const props = defineProps({ artifact: Object })
       <q-icon name="desktop_windows" class="q-mx-xs" />
       {{ artifact.computed.summedMetrics.unique_cell_execution_count }}
     </div>
-
-    <div class="q-ml-lg">
-      <q-tooltip> Last updated </q-tooltip>
-      {{ artifact.updated_at }}
+    <div class="row items-center" v-if="artifact.versions.length > 0">
+      <q-tooltip> Versions </q-tooltip>
+      <q-icon name="commit" class="q-mx-xs" />
+      {{ artifact.versions.length }}
+    </div>
+    <div class="row items-center" v-if="artifact.linked_artifacts.length > 0">
+      <q-tooltip> Linked Artifacts </q-tooltip>
+      <q-icon name="link" class="q-mx-xs" />
+      {{ artifact.linked_artifacts.length }}
+    </div>
+    <div>
+      <div class="q-ml-lg">
+        <q-tooltip> Last updated </q-tooltip>
+        {{ artifact.updated_at }}
+      </div>
     </div>
   </div>
 </template>

--- a/src/stores/artifact.js
+++ b/src/stores/artifact.js
@@ -387,8 +387,7 @@ export const useArtifactsStore = defineStore('artifacts', {
         })
       }
     },
-    async updateArtifactLinks(uuid, _linksToAdd, _linksToRemove) {
-      // Build a replacement list for linked_artifacts and send as a JSON Patch
+    async updateArtifactLinks(uuid, orderedLinks) {
       if (!this.authStore.isAuthenticated) {
         await this.authStore.initKeycloak()
       }
@@ -402,12 +401,12 @@ export const useArtifactsStore = defineStore('artifacts', {
       }
 
       try {
-        // Determine current selection from store artifacts
-        const selected = (this.artifacts || []).filter((a) => a.computed?.isLinkedToArtifact)
-
-        // Map to the serializer format: { relation, linked_artifact }
-        // Use 'collection' as a sensible default relation (matches server tests)
-        const newLinked = selected.map((a) => ({ relation: 'collection', linked_artifact: a.uuid }))
+        // Map the ordered list to the serializer format
+        const newLinked = orderedLinks.map((link, index) => ({
+          relation: link.relation || 'collection', // default relation
+          linked_artifact: link.linked_artifact,
+          order: index, // maintain order
+        }))
 
         const patch = [
           {

--- a/src/util.js
+++ b/src/util.js
@@ -96,5 +96,5 @@ export function filterArtifacts(artifacts = [], options = {}) {
     .filter((a) => !filterOwned || (a.computed && a.computed.canEdit && a.computed.canEdit()))
     .filter((a) => !filterPublic || a.visibility === 'public' || (a.computed && a.computed.hasDoi))
     .filter((a) => !filterDoi || (a.computed && a.computed.hasDoi))
-    .filter((a) => !filterCollection || a.linked_artifacts)
+    .filter((a) => !filterCollection || (a.linked_artifacts && a.linked_artifacts.length > 0))
 }

--- a/src/util.js
+++ b/src/util.js
@@ -46,3 +46,55 @@ export function parseDoi(urn) {
   }
   return parts[4]
 }
+
+// Reusable artifact filtering utility. This is a pure function so it can be
+// used from components, stores, tests, or other utilities. It intentionally
+// does not apply slicing/limits so callers can handle paging / previews.
+export function filterArtifacts(artifacts = [], options = {}) {
+  const {
+    searchText = '',
+    selectedTags = [],
+    selectedBadges = [],
+    filterOwned = false,
+    filterPublic = false,
+    filterDoi = false,
+    filterCollection = false,
+  } = options
+
+  const search = (searchText || '').toLowerCase()
+
+  return (artifacts || [])
+    .filter((a) => {
+      if (search) {
+        const inArtifact = [a.title, a.long_description, a.short_description].some((f) =>
+          f?.toLowerCase().includes(search),
+        )
+        const authors = Array.isArray(a.authors) ? a.authors : []
+        const inAuthors = authors.some((author) =>
+          [author.full_name, author.affiliation, author.email].some((f) =>
+            f?.toLowerCase().includes(search),
+          ),
+        )
+        return inArtifact || inAuthors
+      }
+      return true
+    })
+    .filter((a) => {
+      if (selectedTags && selectedTags.length > 0) {
+        const filteredTags = (a.tags || []).filter((t) => selectedTags.includes(t))
+        return filteredTags.length === selectedTags.length
+      }
+      return true
+    })
+    .filter((a) => {
+      return (
+        !selectedBadges ||
+        selectedBadges.length === 0 ||
+        selectedBadges.every((b) => (a.badges || []).some((ab) => ab.name === b))
+      )
+    })
+    .filter((a) => !filterOwned || (a.computed && a.computed.canEdit && a.computed.canEdit()))
+    .filter((a) => !filterPublic || a.visibility === 'public' || (a.computed && a.computed.hasDoi))
+    .filter((a) => !filterDoi || (a.computed && a.computed.hasDoi))
+    .filter((a) => !filterCollection || a.linked_artifacts)
+}

--- a/src/views/ArtifactView.vue
+++ b/src/views/ArtifactView.vue
@@ -5,6 +5,7 @@ import ArtifactAbout from '@/components/artifact/ArtifactAbout.vue'
 import ArtifactAuthors from '@/components/artifact/ArtifactAuthors.vue'
 import ArtifactCitation from '@/components/artifact/ArtifactCitation.vue'
 import ArtifactVersions from '@/components/artifact/ArtifactVersions.vue'
+import ArtifactLinks from '@/components/artifact/ArtifactLinks.vue'
 import Launch from '@/components/artifact/Launch.vue'
 import Loading from '@/components/Loading.vue'
 
@@ -55,6 +56,7 @@ onMounted(async () => {
             <main class="col-8">
               <ArtifactHeader :artifact="state.artifact" />
               <ArtifactAbout :artifact="state.artifact" />
+              <ArtifactLinks :artifact="state.artifact" />
             </main>
 
             <aside class="col">

--- a/src/views/ArtifactView.vue
+++ b/src/views/ArtifactView.vue
@@ -6,6 +6,7 @@ import ArtifactAuthors from '@/components/artifact/ArtifactAuthors.vue'
 import ArtifactCitation from '@/components/artifact/ArtifactCitation.vue'
 import ArtifactVersions from '@/components/artifact/ArtifactVersions.vue'
 import ArtifactLinks from '@/components/artifact/ArtifactLinks.vue'
+import ArtifactLinksFrom from '@/components/artifact/ArtifactLinksFrom.vue'
 import Launch from '@/components/artifact/Launch.vue'
 import Loading from '@/components/Loading.vue'
 
@@ -66,6 +67,7 @@ onMounted(async () => {
                 :artifact="state.artifact"
                 :version_slug="state.selectedVersion?.slug"
               />
+              <ArtifactLinksFrom :artifact="state.artifact" />
               <ArtifactCitation :artifact="state.artifact" :version="state.selectedVersion" />
             </aside>
           </div>


### PR DESCRIPTION
Updates the UI to support artifact links.
- Add "Related artifacts" section under description
- Add "Related to" section on sidebar - sorted by artifacts with same owner first.
- Adds "Links" metrics - shows how many links an artifact has, if any.

Other changes
- Adds vuedraggable to support reordering of collection items
- Improves TagFilter - This allows us to reuse the search code on the artifact edit page. Also properly handles the reactivity rather than using `watch()` everywhere.
- Fixes a small issue with citation year/month. 