### PR TITLE
Update search mechanism to use new backend API

### DIFF
--- a/src/stores/artifact.js
+++ b/src/stores/artifact.js
@@ -199,10 +199,8 @@ export const useArtifactsStore = defineStore('artifacts', {
         console.error('Failed to load badges:', error)
       }
     },
-    async fetchAllArtifacts() {
-      if (this.artifacts.length > 0) {
-        return
-      }
+    async fetchAllArtifacts(queryParams = {}) {
+      const { q = '', sortBy = '', tags = [] } = queryParams
 
       await this.fetchBadges()
       this.loading = true
@@ -214,11 +212,19 @@ export const useArtifactsStore = defineStore('artifacts', {
       }
       let tokenParam = token ? `?access_token=${token}` : ''
 
+      this.artifacts = []
+      this.artifactDetails = {}
+
       do {
         try {
-          const response = await axios.get(`/artifacts/${tokenParam}`, {
-            params: { after, limit: 21 },
-          })
+          const params = { after, limit: 500 }
+          if (q) params.q = q
+          if (sortBy) params.sort_by = sortBy
+          if (tags && tags.length > 0) {
+            params.tag = tags
+          }
+
+          const response = await axios.get(`/artifacts/${tokenParam}`, { params })
 
           // Append the new artifacts to the store
           // After includes first artifact, so ignore it if set


### PR DESCRIPTION
Main changes:
- switch the limit from ~20 to 500 so it loads them all since that isn't the slow part, but multiple API calls are much slower (maybe auth?)
- use the backend API for searching/sorting (so instead of filtering, now searching, on keypress, the user has to press enter or click the search button once they've typed their query)