### PR TITLE
Add support for images and templates

### DIFF
--- a/src/components/artifact/ArtifactAbout.vue
+++ b/src/components/artifact/ArtifactAbout.vue
@@ -1,6 +1,149 @@
 <script setup>
 import ArtifactMetrics from '@/components/artifact/ArtifactMetrics.vue'
-const props = defineProps({ artifact: Object })
+import { ref, computed } from 'vue'
+import { copyToClipboard } from 'quasar'
+import { parseImageUrn } from '@/util'
+
+const props = defineProps({
+  artifact: Object,
+  selectedVersion: Object,
+})
+
+// I had cors issues getting these dynamically as well, so I hardcoded them
+// but we can probably switch to fetching these from the API
+const SITE_URLS = {
+  'chi-uc': 'https://chi.uc.chameleoncloud.org/',
+  'chi-tacc': 'https://chi.tacc.chameleoncloud.org/',
+  'kvm-tacc': 'https://kvm.tacc.chameleoncloud.org/',
+}
+
+const SITE_NAMES = {
+  'chi-uc': 'CHI@UC',
+  'chi-tacc': 'CHI@TACC',
+  'kvm-tacc': 'KVM@TACC',
+}
+
+function buildImageHref(siteKey, uuid) {
+  const base = SITE_URLS[siteKey]
+  if (!base || siteKey === 'other' || !uuid) {
+    return null
+  }
+  return `${base}project/images/${uuid}`
+}
+
+function findTemplateEnv(version) {
+  if (!version?.environment_setup) return null
+  return version.environment_setup.find((e) => e.type === 'template' && e.arguments)
+}
+
+function isImageVersion(version) {
+  if (!version?.environment_setup) return false
+  return version.environment_setup.some((e) => e.type === 'image')
+}
+
+function collectVersionImages(version, { dedupeSet = null } = {}) {
+  if (!isImageVersion(version)) return []
+
+  const images = []
+
+  const addImageFromUrn = (urn, label) => {
+    if (!urn || !urn.startsWith('urn:trovi:image:')) return
+
+    if (dedupeSet) {
+      if (dedupeSet.has(urn)) return
+      dedupeSet.add(urn)
+    }
+
+    const { siteKey, uuid } = parseImageUrn(urn)
+    const href = buildImageHref(siteKey, uuid)
+
+    images.push({
+      label: label || siteKey,
+      siteKey,
+      uuid,
+      href,
+      urn,
+      slug: version.slug,
+    })
+  }
+
+  if (version.contents?.urn?.startsWith('urn:trovi:image:')) {
+    const link = version.links?.find((l) => l.urn === version.contents.urn)
+    addImageFromUrn(version.contents.urn, link?.label)
+  }
+  else if (Array.isArray(version.links)) {
+    version.links
+      .filter((l) => l.urn && l.urn.startsWith('urn:trovi:image:'))
+      .forEach((l) => addImageFromUrn(l.urn, l.label))
+  }
+
+  return images
+}
+
+const imageList = computed(() => {
+  const versions = props.artifact?.versions || []
+  if (!versions.length) return []
+
+  if (props.selectedVersion) {
+    return collectVersionImages(props.selectedVersion)
+  }
+
+  const allImages = []
+  const seen = new Set()
+
+  const sorted = versions
+    .slice()
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+
+  sorted.forEach((v) => {
+    if (v.deleted) return
+    allImages.push(...collectVersionImages(v, { dedupeSet: seen }))
+  })
+
+  return allImages
+})
+
+const TEMPLATE_LAUNCH_SITES = ['chi-uc', 'chi-tacc']
+
+const templateContent = computed(() => {
+  const versions = props.artifact?.versions || []
+  if (!versions.length) return null
+
+  if (props.selectedVersion) {
+    const env = findTemplateEnv(props.selectedVersion)
+    return env ? { content: env.arguments, slug: props.selectedVersion.slug } : null
+  }
+
+  const visibleVersions = versions.filter((v) => !v.deleted)
+  const sorted = visibleVersions
+    .slice()
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+
+  for (const v of sorted) {
+    const env = findTemplateEnv(v)
+    if (env) return { content: env.arguments, slug: v.slug }
+  }
+
+  return null
+})
+
+// Copy to clipboard
+const copied = ref(false)
+
+function doCopyTemplate() {
+  const content = templateContent.value?.content
+  if (!content) return
+
+  copyToClipboard(content).then(() => {
+    copied.value = true
+    setTimeout(() => {
+      copied.value = false
+    }, 1400)
+  })
+}
+
+// Template help dialog
+const showTemplateHelp = ref(false)
 </script>
 
 <template>
@@ -15,6 +158,150 @@ const props = defineProps({ artifact: Object })
   </div>
 
   <h2 class="text-h6 text-primary q-mb-md">About</h2>
-
   <p class="text-body1 q-mb-md" v-html="artifact.computed.long_description_markup"></p>
+
+  <div v-if="imageList.length" class="q-mt-md">
+    <h3 class="text-h6 text-primary q-mb-sm">Disk Images</h3>
+
+    <div class="row q-col-gutter-md">
+      <div
+        v-for="(img, idx) in imageList"
+        :key="img.slug + '-' + idx"
+        class="col-12 col-md-6 col-lg-4 q-mb-md"
+      >
+        <q-card flat bordered>
+          <q-card-section>
+            <div class="row items-center q-gutter-sm q-mb-xs justify-between">
+              <div>
+                <strong>{{ SITE_NAMES[img.siteKey] || img.siteKey }}</strong>
+                <span class="q-ml-xs text-caption">
+                  Version:
+                  <span class="text-weight-regular">{{ img.slug }}</span>
+                </span>
+              </div>
+
+              <div>
+                <q-btn
+                  v-if="img.href"
+                  color="primary"
+                  size="sm"
+                  :href="img.href"
+                  target="_blank"
+                  label="Launch"
+                  class="q-mt-xs"
+                />
+                <q-btn
+                  v-else
+                  color="grey"
+                  size="sm"
+                  label="Launch Not Available"
+                  disable
+                  class="q-mt-xs"
+                />
+              </div>
+            </div>
+
+            <div>
+              <span class="text-caption" style="font-size: 90%;">Disk Image:</span>
+              <span class="text-caption">{{ img.uuid }}</span>
+            </div>
+          </q-card-section>
+        </q-card>
+      </div>
+    </div>
+
+    <div class="text-caption text-grey-7 q-mt-sm">
+      Note: To use a disk image, you will need to first create a reservation on the target site,
+      and then launch an instance using this disk image within your reservation.
+    </div>
+  </div>
+
+  <div v-if="templateContent" class="q-mt-xl">
+    <h3 class="text-h6 text-primary q-mb-md">Template</h3>
+
+    <q-card flat bordered class="bg-grey-1 q-mb-md" style="overflow: visible;">
+      <q-card-section>
+        <div class="row items-center justify-between q-mb-sm">
+          <div class="text-caption">
+            Version:
+            <span class="text-weight-regular">{{ templateContent.slug }}</span>
+          </div>
+
+          <q-btn
+            size="sm"
+            color="primary"
+            flat
+            dense
+            @click="doCopyTemplate"
+            :label="copied ? 'Copied!' : 'Copy to clipboard'"
+            :icon="copied ? 'check' : 'content_copy'"
+          />
+        </div>
+
+        <pre
+          class="q-ma-none q-pa-md rounded-borders bg-grey-2"
+          style="
+            white-space: pre-wrap;
+            word-break: break-all;
+            font-size: 15px;
+            line-height: 1.45;
+            max-height: 420px;
+            overflow-x: auto;
+            overflow-y: auto;
+          "
+        >{{ templateContent.content }}</pre>
+
+        <div class="row items-center justify-between q-mt-md">
+          <q-btn
+            flat
+            dense
+            size="sm"
+            class="text-caption"
+            color="primary"
+            label="How do I use this template?"
+            @click="showTemplateHelp = true"
+          />
+
+          <div class="row items-center justify-end">
+            <span class="text-body2 q-mr-xs">Launch on:</span>
+            <q-btn
+              v-for="key in TEMPLATE_LAUNCH_SITES"
+              :key="key"
+              color="secondary"
+              size="sm"
+              flat
+              dense
+              :label="SITE_NAMES[key]"
+              :href="SITE_URLS[key] + 'dashboard/project/stacks/'"
+              target="_blank"
+              class="q-ml-xs"
+              style="min-width: 66px; font-size: 14px; padding: 0 4px;"
+            />
+          </div>
+        </div>
+      </q-card-section>
+    </q-card>
+
+    <q-dialog v-model="showTemplateHelp" persistent>
+      <q-card style="max-width: 480px;">
+        <q-card-section class="text-h6">
+          How to use this template
+        </q-card-section>
+
+        <q-card-section class="text-body2">
+          <ol class="q-pl-lg q-mb-none">
+            <li>Click “Copy to clipboard” to copy the template text.</li>
+            <li>Use one of the “Launch on” links to open the Stacks page on your chosen site.</li>
+            <li>Create a new stack and choose the option to use an existing template.</li>
+            <li>Paste the copied template text into the template editor.</li>
+            <li>Review the parameters and launch the stack.</li>
+          </ol>
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn flat label="Close" color="primary" v-close-popup />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </div>
 </template>

--- a/src/components/artifact/ArtifactAbout.vue
+++ b/src/components/artifact/ArtifactAbout.vue
@@ -33,7 +33,7 @@ function buildImageHref(siteKey, uuid) {
 
 function findTemplateEnv(version) {
   if (!version?.environment_setup) return null
-  return version.environment_setup.find((e) => e.type === 'template' && e.arguments)
+  return version.environment_setup.find((e) => e.type === 'heat_template' && e.arguments)
 }
 
 function isImageVersion(version) {

--- a/src/components/artifact/ArtifactVersions.vue
+++ b/src/components/artifact/ArtifactVersions.vue
@@ -1,16 +1,38 @@
 <script setup>
-const props = defineProps({ artifact: Object, version_slug: String })
+import { computed } from 'vue'
+
+const props = defineProps({
+  artifact: Object,
+  version_slug: String,
+  goLatestView: Function,
+})
+
+const safeVersions = computed(() => props.artifact?.versions || [])
 </script>
 
 <template>
   <div class="q-mt-sm">
     <h2 class="text-h6 text-primary q-mb-xs">Versions</h2>
-    <div v-if="artifact.versions?.length">
+
+    <div v-if="safeVersions.length">
       <q-list bordered padding class="q-pa-none">
         <q-item
-          v-for="version in artifact.versions"
+          v-if="goLatestView"
+          clickable
+          :active="!version_slug"
+          @click="goLatestView && goLatestView()"
+        >
+          <q-item-section>
+            <div class="text-subtitle2">Latest View</div>
+            <div class="text-caption">Show most recent version state</div>
+          </q-item-section>
+        </q-item>
+
+        <q-item
+          v-for="version in safeVersions"
           :key="version.uuid"
           clickable
+          :active="version.slug === version_slug"
           :to="`/artifacts/${artifact.uuid}/versions/${version.slug}`"
         >
           <q-item-section>
@@ -19,7 +41,7 @@ const props = defineProps({ artifact: Object, version_slug: String })
                 <div class="text-subtitle2">{{ version.slug }}</div>
                 <div class="text-caption">{{ version.created_at }}</div>
               </div>
-              <div v-if="version.computed.doi" class="col text-caption">
+              <div v-if="version.computed?.doi" class="col text-caption">
                 <a
                   :href="version.computed.doi_url"
                   target="_blank"

--- a/src/components/artifact/Launch.vue
+++ b/src/components/artifact/Launch.vue
@@ -1,12 +1,26 @@
 <script setup>
 import { computed } from 'vue'
-const props = defineProps({ artifact: Object, version_slug: String })
+
+const { artifact, version_slug } = defineProps({
+  artifact: Object,
+  version_slug: String,
+})
 
 const sharingKey = computed(() => {
-  if (typeof window !== 'undefined') {
-    return new URLSearchParams(window.location.search).get('sharing_key')
-  }
-  return null
+  if (typeof window === 'undefined') return null
+  return new URLSearchParams(window.location.search).get('sharing_key')
+})
+
+const selectedVersion = computed(() => {
+  if (!artifact || !version_slug) return null
+  const versions = artifact.versions || []
+  return versions.find((v) => v.slug === version_slug) || null
+})
+
+const isJupyterHub = computed(() => {
+  const v = selectedVersion.value
+  const setup = Array.isArray(v?.environment_setup) ? v.environment_setup : []
+  return setup.some((e) => e.type === 'jupyterhub')
 })
 </script>
 
@@ -16,12 +30,22 @@ const sharingKey = computed(() => {
 
     <div class="q-mb-sm">
       <q-btn
+        v-if="isJupyterHub"
         color="primary"
         label="Launch on Chameleon"
         :href="artifact.computed.get_chameleon_launch_url(version_slug, sharingKey)"
         target="_blank"
         class="full-width"
       />
+      <q-chip
+        v-else
+        color="grey"
+        text-color="white"
+        class="full-width justify-center cursor-inherit"
+        icon="open_in_new"
+      >
+        External Artifact
+      </q-chip>
     </div>
 
     <div class="q-mb-sm">

--- a/src/components/artifact/Launch.vue
+++ b/src/components/artifact/Launch.vue
@@ -42,7 +42,6 @@ const isJupyterHub = computed(() => {
         color="grey"
         text-color="white"
         class="full-width justify-center cursor-inherit"
-        icon="open_in_new"
       >
         External Artifact
       </q-chip>

--- a/src/util.js
+++ b/src/util.js
@@ -98,3 +98,17 @@ export function filterArtifacts(artifacts = [], options = {}) {
     .filter((a) => !filterDoi || (a.computed && a.computed.hasDoi))
     .filter((a) => !filterCollection || (a.linked_artifacts && a.linked_artifacts.length > 0))
 }
+
+export function parseImageUrn(urn) {
+  // Expected: urn:trovi:image:<siteKey>:<uuid>
+  const parts = urn.split(':')
+
+  if (parts.length < 5 || parts[0] !== 'urn' || parts[1] !== 'trovi' || parts[2] !== 'image') {
+    return { siteKey: '', uuid: '' }
+  }
+
+  return {
+    siteKey: parts[3] || '',
+    uuid: parts[4] || '',
+  }
+}

--- a/src/views/EditArtifactView.vue
+++ b/src/views/EditArtifactView.vue
@@ -236,8 +236,8 @@ const submitInfrastructureTemplate = async () => {
   infrastructureTemplateSubmitting.value = true
   try {
     const version_obj = {
-      contents: { urn: `urn:trovi:contents:template:embedded-${Date.now()}` },
-      environment_setup: [{ type: 'template', arguments: infrastructureTemplateContent.value }],
+      contents: { urn: `urn:trovi:contents:heat_template:embedded-${Date.now()}` },
+      environment_setup: [{ type: 'heat_template', arguments: infrastructureTemplateContent.value }],
     }
 
     const newVersion = await artifactsStore.createVersion(state.artifact.uuid, version_obj)
@@ -717,7 +717,7 @@ const reimportArtifact = async () => {
             <div v-if="state.artifact.versions && state.artifact.versions.length" class="q-mt-md q-pa-sm rounded-borders">
               <h4 class="text-subtitle2 q-mb-sm">Infrastructure Templates</h4>
               <div v-for="(v, vi) in state.artifact.versions" :key="vi">
-                <div v-if="v.environment_setup && v.environment_setup.some((e) => e.type === 'template')">
+                <div v-if="v.environment_setup && v.environment_setup.some((e) => e.type === 'heat_template')">
                   <div class="row items-center q-gutter-sm q-mb-sm">
                     <div class="col">
                       <div>{{ v.slug }}</div>

--- a/src/views/EditArtifactView.vue
+++ b/src/views/EditArtifactView.vue
@@ -715,7 +715,7 @@ const reimportArtifact = async () => {
             </div>
 
             <div v-if="state.artifact.versions && state.artifact.versions.length" class="q-mt-md q-pa-sm rounded-borders">
-              <h4 class="text-subtitle2 q-mb-sm">Infrastructure Templates</h4>
+              <h4 class="text-subtitle2 q-mb-sm">Heat Templates</h4>
               <div v-for="(v, vi) in state.artifact.versions" :key="vi">
                 <div v-if="v.environment_setup && v.environment_setup.some((e) => e.type === 'heat_template')">
                   <div class="row items-center q-gutter-sm q-mb-sm">
@@ -734,19 +734,19 @@ const reimportArtifact = async () => {
             </div>
 
             <div class="q-mt-md q-pa-sm rounded-borders">
-              <h4 class="text-subtitle2 q-mb-sm">Add Infrastructure Template</h4>
+              <h4 class="text-subtitle2 q-mb-sm">Add Heat Template</h4>
               <div class="row q-gutter-sm items-center q-mb-sm">
                 <q-input
                   v-model="infrastructureTemplateContent"
                   type="textarea"
-                  label="Add Template Text Here"
+                  label="Add Heat Template Text Here"
                   dense
                   class="col"
                 />
               </div>
               <div class="row q-gutter-sm">
                 <q-btn
-                  label="Create Template Version"
+                  label="Create Heat Template Version"
                   color="primary"
                   :loading="infrastructureTemplateSubmitting"
                   @click="submitInfrastructureTemplate"


### PR DESCRIPTION
Required backend changes: https://github.com/ChameleonCloud/trovi/pull/239

Here are some screenshots.

Artifact with disk images:
<img width="1171" height="903" alt="Screenshot 2025-12-22 at 11 24 55" src="https://github.com/user-attachments/assets/71ea8ca8-d57a-486c-9c11-ea183f3d0e0d" />

Artifact with a template:
<img width="1172" height="899" alt="Screenshot 2025-12-22 at 11 25 12" src="https://github.com/user-attachments/assets/b67ea177-0fca-4d06-af5c-c96f432d41b2" />

Template help:
<img width="1171" height="894" alt="Screenshot 2025-12-22 at 11 25 25" src="https://github.com/user-attachments/assets/9c0b8703-0765-4fc8-a5c1-ed2e5ecf254a" />

Edit artifact page to add images and templates:
<img width="1155" height="1014" alt="Screenshot 2025-12-22 at 11 26 08" src="https://github.com/user-attachments/assets/bba7a962-5116-4e68-9b45-940cebc8b0fa" />