### PR TITLE
Revert use of pages for loading artifacts

### DIFF
--- a/src/components/artifact/ArtifactList.vue
+++ b/src/components/artifact/ArtifactList.vue
@@ -128,9 +128,6 @@ function showAllArtifacts() {
       <div>
         <template v-if="!isSearching">
           Displaying {{ displayedArtifacts.length }} of {{ artifactsStore.artifacts.length }} artifacts
-          <span v-if="artifactsStore.loadingMore" class="text-grey-7">
-            <QSpinnerDots size="1em" class="q-ml-sm" /> loading more...
-          </span>
         </template>
         <template v-else>
           <QSpinnerDots class="q-mr-sm" size="1.6em" />
@@ -178,7 +175,7 @@ function showAllArtifacts() {
   >
     <q-btn
       @click="showAllArtifacts"
-      color="primary" 
+      color="primary"
       class="full-width justify-center"
     >
       View More Artifacts

--- a/src/stores/artifact.js
+++ b/src/stores/artifact.js
@@ -189,7 +189,6 @@ export const useArtifactsStore = defineStore('artifacts', {
     artifacts: [],
     artifactDetails: {},
     loading: false,
-    loadingMore: false,
     badges_loaded: false,
     processed_badges: {
       badges: {},
@@ -232,7 +231,6 @@ export const useArtifactsStore = defineStore('artifacts', {
 
       await this.fetchBadges()
       this.loading = true
-      this.loadingMore = false
       let after = null
 
       var token = undefined
@@ -244,11 +242,9 @@ export const useArtifactsStore = defineStore('artifacts', {
       this.artifacts = []
       this.artifactDetails = {}
 
-      let isFirstPage = true
-
       do {
         try {
-          const params = { after, limit: isFirstPage ? 50 : 500 }
+          const params = { after, limit: 500 }
           if (q) params.q = q
           if (sortBy) params.sort_by = sortBy
           if (tags && tags.length > 0) {
@@ -265,28 +261,17 @@ export const useArtifactsStore = defineStore('artifacts', {
             this.artifactDetails[artifact.uuid] = processArtifact(this, artifact)
           })
 
-          // Show results after first page loads
-          if (isFirstPage) {
-            this.loading = false
-            isFirstPage = false
-          }
-
           // Update the `after` parameter for the next call
           after =
             response.data.next.after && newArtifacts.length > 0
               ? newArtifacts[newArtifacts.length - 1].uuid
               : null
-
-          if (after !== null && !this.loadingMore) {
-            this.loadingMore = true
-          }
         } catch (error) {
           console.error('Failed to load artifacts:', error)
           break
         }
       } while (after !== null)
       this.loading = false
-      this.loadingMore = false
     },
     async fetchArtifactById(uuid, sharing_key) {
       await this.fetchBadges()


### PR DESCRIPTION
Unfortunately the use of pages from the backend didn't help speed up loading the artifacts on the main dashboard page. Instead it actually slowed it down. Instead of 1 8-10s call to load the artifacts, it resulted in 1 8-10s call to load 50 artifacts, and a second 8-10s call to load the rest. We'll need to tackle that slowness on the backend, at which point we can consider adding back some form of pagination.

From here: https://github.com/ChameleonCloud/trovi-dashboard/commit/3fceab06f38ba802d634ca59c3be71c42c934c64